### PR TITLE
spike: demonstrate RFC-0001 payload-integrity fallback

### DIFF
--- a/src/proxy/server.zig
+++ b/src/proxy/server.zig
@@ -82,6 +82,10 @@ const ResponseTruncated = struct {
     max_size: usize,
 };
 
+const ModifiedPayloadBypassed = struct {
+    reason: []const u8,
+};
+
 const UpstreamRetry = struct {
     attempt: u8,
     max_retries: u8,
@@ -529,9 +533,13 @@ fn proxyHandler(ctx: *ServerContext, req: *httpz.Request, res: *httpz.Response, 
             if (encoding != .none) {
                 body_to_send = compressIfNeeded(req.arena, module_result.modified_body, encoding) catch |err| blk: {
                     ctx.bus.warn(CompressError{ .err = @errorName(err) });
-                    break :blk module_result.modified_body; // Fall back to uncompressed
+                    // Payload integrity first: if we cannot safely re-encode a modified payload,
+                    // bypass modification and forward the original body unchanged.
+                    ctx.bus.warn(ModifiedPayloadBypassed{ .reason = "recompression_failed" });
+                    break :blk original_body;
                 };
-                compressed_allocated = (body_to_send.ptr != module_result.modified_body.ptr);
+                compressed_allocated = (body_to_send.ptr != module_result.modified_body.ptr and
+                    body_to_send.ptr != original_body.ptr);
             }
             defer if (compressed_allocated) req.arena.free(body_to_send);
 


### PR DESCRIPTION
## Why
This spike demonstrates one concrete principle from RFC-0001 (Edge Proxy Runtime Contract):

- if transformed payload integrity is uncertain, do not forward risky mutated data
- fallback to original payload behavior instead

RFC reference: https://github.com/usetero/rfcs/pull/1

## What this spike changes
When a module returns a modified payload and recompression fails, the proxy now bypasses the modified payload and forwards the original request body unchanged.

## Why this is useful
This is a small, isolated example of the runtime contract in action:
- integrity over best-effort mutation
- explicit safe fallback
- no broad Theme 1 refactor

## Validation
- `zig build test`
