### PR TITLE
chore: use the company Hermit source overlay

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -28,10 +28,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.TERO_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.TERO_BOT_PRIVATE_SIGNING_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure Git for private Hermit sources
+        run: git config --global url.https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/.insteadOf https://github.com/
 
       - name: Setup Hermit
         uses: cashapp/activate-hermit@12a728b03ad41eace0f9abaf98a035e7e8ea2318 # v1.1.4

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,2 +1,4 @@
+sources = ["https://github.com/usetero/hermit-packages.git", "https://github.com/cashapp/hermit-packages.git"]
+
 github-token-auth {
 }


### PR DESCRIPTION
## Summary\n- configure Hermit to use the usetero package overlay first\n- keep cashapp hermit-packages as the fallback source so existing packages keep resolving\n\n## Validation\n- ./bin/hermit status