### PR TITLE
feat(config): make connection and memory limits configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ PLAN*.md
 sample*
 .rewrite/
 .venv/
+config.test.json

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,8 +37,8 @@
             .hash = "zimdjson-0.1.1-89pgxQlXBgAl5hBPQrMFdumnb9Z36oftC7qkURHJwLEG",
         },
         .policy_zig = .{
-            .url = "https://github.com/usetero/policy-zig/archive/refs/tags/v0.4.1.tar.gz",
-            .hash = "policy_zig-0.1.7-5_dp3n5aEQAf9-263x9Cme9QPNGJvEbDCKjfl5HD-QyI",
+            .url = "https://github.com/usetero/policy-zig/archive/refs/tags/v0.4.2.tar.gz",
+            .hash = "policy_zig-0.1.7-5_dp3hR_EQDLFTxhkAAiY12YrW3b2N2cac0LNgxONIB4",
         },
         .metrics = .{
             .url = "git+https://github.com/karlseguin/metrics.zig?ref=master#1621f82e7ecf2b3dddf5730bf52761af354a7080",

--- a/charts/tero-edge/README.md
+++ b/charts/tero-edge/README.md
@@ -101,7 +101,10 @@ Provide auth either via:
 | `config.metricsUrl`                 | string | `https://api.datadoghq.com`                    | Metrics upstream URL                                          |
 | `config.logLevel`                   | string | `info`                                         | Log level                                                     |
 | `config.maxBodySize`                | int    | `1048576`                                      | Max request body bytes                                        |
-| `config.maxUpstreamRetries`         | int    | `10`                                           | Max upstream retries                                          |
+| `config.maxConnections`             | int    | `256`                                          | Max concurrent connections (dominant memory cap)             |
+| `config.maxDecodedBytes`            | int    | `null`                                         | Post-decompression body ceiling (defaults to maxBodySize)    |
+| `config.workerCount`                | int    | `null`                                         | httpz event-loop workers (null = default 1)                  |
+| `config.threadPoolCount`            | int    | `null`                                         | httpz handler threads (null = default 32; scales memory)     |
 | `config.service.name`               | string | `""`                                           | Service name sent on policy sync (omitted if empty)           |
 | `config.service.namespace`          | string | `""`                                           | Service namespace sent on policy sync (omitted if empty)      |
 | `config.service.version`            | string | `""`                                           | Service version sent on policy sync (omitted if empty)        |

--- a/charts/tero-edge/templates/configmap.yaml
+++ b/charts/tero-edge/templates/configmap.yaml
@@ -14,7 +14,16 @@ data:
       "metrics_url": {{ .Values.config.metricsUrl | quote }},
       "log_level": {{ .Values.config.logLevel | quote }},
       "max_body_size": {{ int .Values.config.maxBodySize }},
-      "max_upstream_retries": {{ int .Values.config.maxUpstreamRetries }},
+      "max_connections": {{ int .Values.config.maxConnections }},
+      {{- with .Values.config.maxDecodedBytes }}
+      "max_decoded_bytes": {{ int . }},
+      {{- end }}
+      {{- with .Values.config.workerCount }}
+      "worker_count": {{ int . }},
+      {{- end }}
+      {{- with .Values.config.threadPoolCount }}
+      "thread_pool_count": {{ int . }},
+      {{- end }}
       {{- $svc := dict }}
       {{- with .Values.config.service }}
       {{- if .name }}{{ $svc = set $svc "name" .name }}{{ end }}

--- a/charts/tero-edge/values.yaml
+++ b/charts/tero-edge/values.yaml
@@ -92,7 +92,21 @@ config:
   metricsUrl: "https://api.datadoghq.com"
   logLevel: "info"
   maxBodySize: 1048576
-  maxUpstreamRetries: 10
+
+  # Max concurrent connections — the dominant memory/throughput cap (memory
+  # scales ~ maxConnections x maxBodySize). Also settable via the
+  # TERO_MAX_CONNECTIONS env override.
+  maxConnections: 256
+
+  # Optional. Post-decompression body ceiling; defaults to maxBodySize when
+  # null. Raise to admit payloads that decompress larger than the raw cap.
+  maxDecodedBytes: null
+
+  # Optional httpz tuning (null = built-in defaults). workerCount is event-loop
+  # workers (default 1); threadPoolCount is request-handler threads (default
+  # 32) and multiplies the per-thread pipeline-scratch memory floor.
+  workerCount: null
+  threadPoolCount: null
 
   # Service identity sent to the control plane on policy sync. name, namespace,
   # and version scope/match policies to this service; set them in production.

--- a/src/config/types.zig
+++ b/src/config/types.zig
@@ -43,6 +43,21 @@ pub const ProxyConfig = struct {
 
     max_body_size: u32 = 1024 * 1024, // 1MB
 
+    /// Post-decompression body ceiling; defaults to `max_body_size` when unset.
+    /// Raise it to admit payloads that decompress larger than the raw cap.
+    max_decoded_bytes: ?u32 = null,
+
+    /// Max concurrent connections; the dominant memory/throughput knob (see
+    /// limits.zig). Also honors the `TERO_MAX_CONNECTIONS` env override.
+    max_connections: u32 = 256,
+
+    /// httpz event-loop worker count (null = httpz default of 1).
+    worker_count: ?u16 = null,
+
+    /// httpz request-handler thread-pool count (null = httpz default of 32).
+    /// Multiplies the per-thread pipeline-scratch memory floor.
+    thread_pool_count: ?u16 = null,
+
     // Policy providers - array of provider configurations
     policy_providers: []ProviderConfig = &.{},
 

--- a/src/core/limits.zig
+++ b/src/core/limits.zig
@@ -56,6 +56,12 @@ pub const Limits = struct {
     max_connections: usize,
     /// Per-request body ceiling, from the frozen `ProxyConfig.max_body_size`.
     max_body_size: u32,
+    /// Post-decompression body ceiling; defaults to `max_body_size`.
+    max_decoded_bytes: usize = 0,
+    /// httpz event-loop worker count (null = httpz default).
+    worker_count: ?u16 = null,
+    /// httpz request-handler thread-pool count (null = httpz default).
+    thread_pool_count: ?u16 = null,
     record_scratch: usize,
     recv_buf: usize,
     send_buf: usize,
@@ -69,24 +75,29 @@ pub const Limits = struct {
     zstd_window_len: usize,
     conn_arena_reserve: usize,
 
-    pub fn resolve(
+    /// Inputs to `resolve` that originate from config (`ProxyConfig`), with
+    /// the `TERO_*` env overrides already applied by zonfig. No env reads here.
+    pub const ResolveOptions = struct {
         max_body_size: u32,
-        environ_map: *const std.process.Environ.Map,
-    ) Limits {
-        const max_connections = parseEnvUsize(
-            environ_map,
-            "TERO_MAX_CONNECTIONS",
-            DEFAULT_MAX_CONNECTIONS,
-        );
-        std.debug.assert(max_connections > 0);
+        max_decoded_bytes: ?u32 = null,
+        max_connections: u32 = DEFAULT_MAX_CONNECTIONS,
+        worker_count: ?u16 = null,
+        thread_pool_count: ?u16 = null,
+    };
+
+    pub fn resolve(opts: ResolveOptions) Limits {
+        std.debug.assert(opts.max_connections > 0);
         const zstd_window_len = std.math.clamp(
-            @as(usize, max_body_size),
+            @as(usize, opts.max_body_size),
             ZSTD_WINDOW_MIN,
             ZSTD_WINDOW_MAX,
         );
         return .{
-            .max_connections = max_connections,
-            .max_body_size = max_body_size,
+            .max_connections = opts.max_connections,
+            .max_body_size = opts.max_body_size,
+            .max_decoded_bytes = opts.max_decoded_bytes orelse opts.max_body_size,
+            .worker_count = opts.worker_count,
+            .thread_pool_count = opts.thread_pool_count,
             .record_scratch = RECORD_SCRATCH_BYTES,
             .recv_buf = RECV_BUF_BYTES,
             .send_buf = SEND_BUF_BYTES,
@@ -127,22 +138,8 @@ pub const Limits = struct {
     }
 };
 
-fn parseEnvUsize(
-    environ_map: *const std.process.Environ.Map,
-    key: []const u8,
-    default: usize,
-) usize {
-    const raw = environ_map.get(key) orelse return default;
-    return std.fmt.parseUnsigned(usize, raw, 10) catch |err| {
-        log.warn("ignoring {s}={s}: {s}", .{ key, raw, @errorName(err) });
-        return default;
-    };
-}
-
 test "Limits budget formula is locked" {
-    var env_map = std.process.Environ.Map.init(std.testing.allocator);
-    defer env_map.deinit();
-    const limits: Limits = .resolve(1024 * 1024, &env_map);
+    const limits: Limits = .resolve(.{ .max_body_size = 1024 * 1024 });
 
     // Hand-computed with the default 1 MiB max_body_size:
     //   zstd window = clamp(1M, 256K, 8M)        = 1024 KiB
@@ -157,17 +154,22 @@ test "Limits budget formula is locked" {
     try std.testing.expectEqual(@as(usize, 1736 * 1024), limits.perConnBytes());
     try std.testing.expectEqual(@as(usize, 256 * 1752 * 1024), limits.steadyStateBytes());
     try std.testing.expectEqual(@as(u32, 1024 * 1024), limits.max_body_size);
+    // max_decoded_bytes defaults to max_body_size; thread knobs default off.
+    try std.testing.expectEqual(@as(usize, 1024 * 1024), limits.max_decoded_bytes);
+    try std.testing.expectEqual(@as(?u16, null), limits.worker_count);
+    try std.testing.expectEqual(@as(?u16, null), limits.thread_pool_count);
 }
 
-test "Limits respects TERO_MAX_CONNECTIONS override and rejects garbage" {
-    var env_map = std.process.Environ.Map.init(std.testing.allocator);
-    defer env_map.deinit();
-    try env_map.put("TERO_MAX_CONNECTIONS", "32");
-
-    const limits: Limits = .resolve(1024 * 1024, &env_map);
+test "Limits resolves config-supplied knobs" {
+    const limits: Limits = .resolve(.{
+        .max_body_size = 1024 * 1024,
+        .max_decoded_bytes = 4 * 1024 * 1024,
+        .max_connections = 32,
+        .worker_count = 2,
+        .thread_pool_count = 8,
+    });
     try std.testing.expectEqual(@as(usize, 32), limits.max_connections);
-
-    try env_map.put("TERO_MAX_CONNECTIONS", "not-a-number");
-    const fallback: Limits = .resolve(1024 * 1024, &env_map);
-    try std.testing.expectEqual(DEFAULT_MAX_CONNECTIONS, fallback.max_connections);
+    try std.testing.expectEqual(@as(usize, 4 * 1024 * 1024), limits.max_decoded_bytes);
+    try std.testing.expectEqual(@as(?u16, 2), limits.worker_count);
+    try std.testing.expectEqual(@as(?u16, 8), limits.thread_pool_count);
 }

--- a/src/frontend/httpz/server.zig
+++ b/src/frontend/httpz/server.zig
@@ -34,6 +34,10 @@ pub fn configFromLimits(limits: limits_mod.Limits, address: [4]u8, port: u16) ht
             .max_body_size = limits.max_body_size,
             .buffer_size = limits.recv_buf,
         },
+        // null => httpz defaults (1 worker, 32 pool threads). thread_pool count
+        // multiplies the per-thread pipeline-scratch floor (see ThreadBufs).
+        .workers = .{ .count = limits.worker_count },
+        .thread_pool = .{ .count = limits.thread_pool_count },
     };
 }
 
@@ -335,7 +339,7 @@ pub const Handler = struct {
             .decode = pipe.codec,
             .format = pipe.format,
             .encode = pipe.codec,
-            .max_decoded_bytes = ctx.limits.max_body_size,
+            .max_decoded_bytes = ctx.limits.max_decoded_bytes,
             .zstd_window_len = ctx.limits.zstd_window_len,
         }, &body_reader, &body_writer.writer, .{
             .decoder = bufs.decode,
@@ -512,19 +516,26 @@ fn stdMethod(method: httpz.Method) ?std.http.Method {
 const testing = std.testing;
 
 test "httpz config derives from limits" {
-    var env_map = std.process.Environ.Map.init(testing.allocator);
-    defer env_map.deinit();
-    const limits: limits_mod.Limits = .resolve(1024 * 1024, &env_map);
+    const limits: limits_mod.Limits = .resolve(.{ .max_body_size = 1024 * 1024 });
 
     const config = configFromLimits(limits, .{ 127, 0, 0, 1 }, 8080);
     try testing.expectEqual(@as(?usize, 1024 * 1024), config.request.max_body_size);
     try testing.expectEqual(@as(?usize, limits_mod.RECV_BUF_BYTES), config.request.buffer_size);
-    // Worker/thread-pool counts ride httpz defaults — the master-proven
-    // shape. If this assert fires, someone tuned them: move the knob into
-    // limits.zig and update PLAN-FRONTEND-SWAP.md §5.
+    // Unset worker/thread-pool counts ride httpz defaults (null).
     try testing.expectEqual(@as(?u16, null), config.workers.count);
     try testing.expectEqual(@as(?u16, null), config.thread_pool.count);
     try testing.expectEqual(@as(u16, 8080), config.address.ip.ip4.port);
+}
+
+test "httpz config carries configured worker/thread-pool counts" {
+    const limits: limits_mod.Limits = .resolve(.{
+        .max_body_size = 1024 * 1024,
+        .worker_count = 2,
+        .thread_pool_count = 8,
+    });
+    const config = configFromLimits(limits, .{ 127, 0, 0, 1 }, 8080);
+    try testing.expectEqual(@as(?u16, 2), config.workers.count);
+    try testing.expectEqual(@as(?u16, 8), config.thread_pool.count);
 }
 
 test "httpz method maps onto service and std methods" {

--- a/src/frontend/stdio/conn.zig
+++ b/src/frontend/stdio/conn.zig
@@ -294,7 +294,7 @@ fn execPipeStream(
         .decode = pipe.codec,
         .format = pipe.format,
         .encode = pipe.codec,
-        .max_decoded_bytes = ctx.limits.max_body_size,
+        .max_decoded_bytes = ctx.limits.max_decoded_bytes,
         .zstd_window_len = ctx.limits.zstd_window_len,
     }, body_reader, &body_writer.writer, .{
         .decoder = env.slab.decodeBuf(conn_id),

--- a/src/lambda_main.zig
+++ b/src/lambda_main.zig
@@ -251,10 +251,14 @@ pub fn main(init: std.process.Init) !void {
 
     // Create Datadog module configuration
     const kinds: []const edge.distro.ServiceKind = &lambda_service_kinds;
-    const engine = try app.Engine.create(allocator, io, init.environ_map, bus, &registry, &runtime_metrics, kinds, .{
+    const engine = try app.Engine.create(allocator, io, bus, &registry, &runtime_metrics, kinds, .{
         .listen_address = config.listen_address,
         .listen_port = config.listen_port,
         .max_body_size = config.max_body_size,
+        .max_decoded_bytes = config.max_decoded_bytes,
+        .max_connections = config.max_connections,
+        .worker_count = config.worker_count,
+        .thread_pool_count = config.thread_pool_count,
         .upstream_url = config.upstream_url,
         .logs_url = config.logs_url,
         .metrics_url = config.metrics_url,

--- a/src/runtime/app.zig
+++ b/src/runtime/app.zig
@@ -416,6 +416,14 @@ pub fn run(init: std.process.Init, distribution: mode.Distribution) !void {
     };
     defer zonfig.deinit(ProxyConfig, allocator, config);
 
+    // Reset the bus level from config now that JSON + env (TERO_LOG_LEVEL) are merged.
+    bus.setLevel(switch (config.log_level) {
+        .debug => .debug,
+        .info => .info,
+        .warn => .warn,
+        .err => .err,
+    });
+
     var instance_id_buf: [64]u8 = undefined;
     const instance_id = try std.fmt.bufPrint(&instance_id_buf, "edge-{d}-{d}", .{
         std.Io.Timestamp.now(io, .real).toMilliseconds(),

--- a/src/runtime/app.zig
+++ b/src/runtime/app.zig
@@ -214,6 +214,10 @@ pub const EngineOptions = struct {
     listen_address: [4]u8,
     listen_port: u16,
     max_body_size: u32,
+    max_decoded_bytes: ?u32 = null,
+    max_connections: u32 = limits_mod.DEFAULT_MAX_CONNECTIONS,
+    worker_count: ?u16 = null,
+    thread_pool_count: ?u16 = null,
     upstream_url: []const u8,
     logs_url: ?[]const u8 = null,
     metrics_url: ?[]const u8 = null,
@@ -235,7 +239,6 @@ pub const Engine = struct {
     pub fn create(
         allocator: std.mem.Allocator,
         io: std.Io,
-        environ_map: *const std.process.Environ.Map,
         bus: *EventBus,
         registry: *policy.Registry,
         metrics: ?*RuntimeMetrics,
@@ -247,7 +250,13 @@ pub const Engine = struct {
 
         self.allocator = allocator;
         self.io = io;
-        self.limits = .resolve(options.max_body_size, environ_map);
+        self.limits = .resolve(.{
+            .max_body_size = options.max_body_size,
+            .max_decoded_bytes = options.max_decoded_bytes,
+            .max_connections = options.max_connections,
+            .worker_count = options.worker_count,
+            .thread_pool_count = options.thread_pool_count,
+        });
         self.limits.logStartup();
 
         self.upstreams = upstream_mod.UpstreamManager.init(io, allocator, self.limits.max_connections);
@@ -438,10 +447,14 @@ pub fn run(init: std.process.Init, distribution: mode.Distribution) !void {
     installSegfaultHandler();
 
     const kinds = serviceKindsFor(distribution);
-    const engine = try Engine.create(allocator, io, init.environ_map, bus, &registry, &runtime_metrics, kinds, .{
+    const engine = try Engine.create(allocator, io, bus, &registry, &runtime_metrics, kinds, .{
         .listen_address = config.listen_address,
         .listen_port = config.listen_port,
         .max_body_size = config.max_body_size,
+        .max_decoded_bytes = config.max_decoded_bytes,
+        .max_connections = config.max_connections,
+        .worker_count = config.worker_count,
+        .thread_pool_count = config.thread_pool_count,
         .upstream_url = config.upstream_url,
         .logs_url = config.logs_url,
         .metrics_url = config.metrics_url,


### PR DESCRIPTION
Move max_connections off the env-only TERO_MAX_CONNECTIONS read into ProxyConfig so it loads from config.json via zonfig; the TERO_* override still works through zonfig's env-override layer. Add max_decoded_bytes (defaults to max_body_size) and httpz worker_count / thread_pool_count, the latter driving the per-thread pipeline-scratch memory floor.

Expose all four in the Helm chart and drop max_upstream_retries, which the chart wrote to config.json but the binary never read.