### PR TITLE
fix(ci): release the chart through release-please so it gets tagged

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -3,7 +3,10 @@ name: Publish Helm Chart
 on:
   push:
     tags:
-      - "v*"
+      # Chart tags only. Publishing on app (v*) tags too would repackage the
+      # current, unchanged chart version with a new appVersion and overwrite an
+      # already-published .tgz. appVersion changes ship with the next chart
+      # release instead.
       - "tero-edge-chart-v*"
   workflow_dispatch:
 

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,17 @@
 # 3. Review and merge the release PR
 # 4. GitHub release is created automatically
 #
-# DO NOT EDIT: Managed by Terraform at https://github.com/usetero/infrastructure
+# Chart versioning:
+# release-please owns charts/tero-edge entirely (release-type: helm in
+# release-please-config.json). Do not hand-bump the chart version or
+# .release-please-manifest.json from this workflow: release-please only tags
+# what it lists in the release PR body it generates, so a version written in
+# out-of-band gets published by publish-helm-chart.yaml but never tagged or
+# released. Chart appVersion tracks the app automatically via the root
+# package's extra-files jsonpath.
+#
+# Seeded by Terraform at https://github.com/usetero/infrastructure, but content
+# changes here are not overwritten (bootstrapped file, ignore_changes=[content]).
 name: Release please
 
 on:
@@ -46,139 +56,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        id: release_please
         with:
           token: ${{ steps.generate-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Resolve root release PR
-        id: resolve_pr
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-
-          pr_number=""
-          pr_branch=""
-
-          prs_json='${{ steps.release_please.outputs.prs }}'
-          pr_json='${{ steps.release_please.outputs.pr }}'
-
-          # Prefer the release PR for the repository root package (path ".").
-          if [ -n "${prs_json}" ] && [ "${prs_json}" != "[]" ]; then
-            pr_number="$(echo "${prs_json}" | jq -r '.[] | select((.path // "") == ".") | .number' | head -n1 || true)"
-          fi
-
-          # Backward-compatible fallback for older output shapes/titles.
-          if [ -z "${pr_number}" ] && [ -n "${prs_json}" ] && [ "${prs_json}" != "[]" ]; then
-            pr_number="$(echo "${prs_json}" | jq -r '.[] | select((.title // "") | startswith("chore(master): release ")) | .number' | head -n1 || true)"
-          fi
-
-          if [ -z "${pr_number}" ] && [ -n "${pr_json}" ] && [ "${pr_json}" != "null" ]; then
-            pr_path="$(echo "${pr_json}" | jq -r '.path // ""')"
-            title="$(echo "${pr_json}" | jq -r '.title // ""')"
-            if [ "${pr_path}" = "." ] || [[ "${title}" == chore\(master\):\ release\ * ]]; then
-              pr_number="$(echo "${pr_json}" | jq -r '.number // empty')"
-            fi
-          fi
-
-          if [ -z "${pr_number}" ]; then
-            pr_number="$(gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&head=${GITHUB_REPOSITORY_OWNER}:release-please--branches--master" --jq '.[0].number // empty' || true)"
-          fi
-
-          if [ -n "${pr_number}" ]; then
-            pr_branch="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.head.ref')"
-          fi
-
-          echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
-          echo "pr_branch=${pr_branch}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout release PR branch
-        if: ${{ steps.resolve_pr.outputs.pr_branch != '' }}
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          ref: ${{ steps.resolve_pr.outputs.pr_branch }}
-          token: ${{ steps.generate-token.outputs.token }}
-
-      - name: Bump chart version for app release PR
-        if: ${{ steps.resolve_pr.outputs.pr_branch != '' }}
-        env:
-          PR_BRANCH: ${{ steps.resolve_pr.outputs.pr_branch }}
-        run: |
-          set -euo pipefail
-
-          chart_file="charts/tero-edge/Chart.yaml"
-          manifest_file=".release-please-manifest.json"
-          git fetch origin master --depth=1
-
-          current_version="$(awk '/^version:[[:space:]]*/ {print $2; exit}' "${chart_file}")"
-          if ! [[ "${current_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Unsupported chart version format: ${current_version}" >&2
-            exit 1
-          fi
-          base_chart_version="$(git show "origin/master:${chart_file}" | awk '/^version:[[:space:]]*/ {print $2; exit}' || true)"
-          if ! [[ "${base_chart_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            base_chart_version="${current_version}"
-          fi
-
-          # Determine root app bump type by comparing manifest versions:
-          # - origin/master: previous app version
-          # - release PR branch: new app version
-          app_version_new="$(jq -r '.["."] // empty' "${manifest_file}")"
-          app_version_old=""
-          if git cat-file -e "origin/master:${manifest_file}" 2>/dev/null; then
-            app_version_old="$(git show "origin/master:${manifest_file}" | jq -r '.["."] // empty' || true)"
-          fi
-
-          if [ "${app_version_new}" = "${app_version_old}" ]; then
-            echo "Root app version is unchanged; skipping chart bump."
-            exit 0
-          fi
-
-          bump_kind="patch"
-          if [[ "${app_version_new}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${app_version_old}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            IFS='.' read -r app_old_major app_old_minor app_old_patch <<< "${app_version_old}"
-            IFS='.' read -r app_new_major app_new_minor app_new_patch <<< "${app_version_new}"
-            if [ "${app_new_major}" -gt "${app_old_major}" ]; then
-              bump_kind="major"
-            elif [ "${app_new_minor}" -gt "${app_old_minor}" ]; then
-              bump_kind="minor"
-            else
-              bump_kind="patch"
-            fi
-          fi
-
-          # Use origin/master chart version as the bump base so reruns are idempotent.
-          IFS='.' read -r chart_major chart_minor chart_patch <<< "${base_chart_version}"
-          case "${bump_kind}" in
-            major)
-              new_version="$((chart_major + 1)).0.0"
-              ;;
-            minor)
-              new_version="${chart_major}.$((chart_minor + 1)).0"
-              ;;
-            *)
-              new_version="${chart_major}.${chart_minor}.$((chart_patch + 1))"
-              ;;
-          esac
-
-          awk -v v="${new_version}" '
-            /^version:[[:space:]]*/ && !done { print "version: " v; done=1; next }
-            { print }
-          ' "${chart_file}" > "${chart_file}.tmp"
-          mv "${chart_file}.tmp" "${chart_file}"
-
-          tmp_manifest="$(mktemp)"
-          jq --arg v "${new_version}" '.["charts/tero-edge"] = $v' "${manifest_file}" > "${tmp_manifest}"
-          mv "${tmp_manifest}" "${manifest_file}"
-
-          if git diff --quiet -- "${chart_file}" "${manifest_file}"; then
-            exit 0
-          fi
-
-          git config user.name "tero-bot[bot]"
-          git config user.email "tero-bot[bot]@users.noreply.github.com"
-          git add "${chart_file}" "${manifest_file}"
-          git commit -m "chore(charts/tero-edge): bump chart version for app release"
-          git push origin "HEAD:${PR_BRANCH}"

--- a/.github/workflows/sync-chart-appversion.yaml
+++ b/.github/workflows/sync-chart-appversion.yaml
@@ -1,0 +1,126 @@
+---
+# Sync Chart appVersion after an app release
+#
+# Why this exists:
+# The chart should ship the app version that was just released, but the chart
+# must still be versioned and released by release-please so it gets a tag, a
+# GitHub release and a changelog entry.
+#
+# release-please only tags what it lists in the release PR body it generates,
+# so the chart version cannot be hand-bumped: a version written in out-of-band
+# gets published but never tagged. Instead this workflow opens an ordinary PR
+# carrying a real conventional commit that touches charts/tero-edge. Merging it
+# gives release-please a `fix` for the chart package, which then releases the
+# chart through its normal path.
+#
+# Flow:
+# 1. App release v1.30.0 is published
+# 2. This workflow opens "fix(charts): sync appVersion to 1.30.0"
+# 3. Merging it makes release-please open a chart release PR
+# 4. Merging that tags tero-edge-chart-v0.16.2 and publishes the chart
+#
+# Note: appVersion is deliberately NOT in release-please-config.json
+# extra-files. If release-please wrote it during the app release PR, the commit
+# below would be an empty diff and the chart would never be released.
+name: Sync chart appVersion
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "App version to sync (without leading v)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    # Only app releases. Chart releases are tagged tero-edge-chart-v* and must
+    # not retrigger this.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.TERO_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.TERO_BOT_PRIVATE_SIGNING_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: master
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Open appVersion sync PR
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RAW_VERSION: >-
+            ${{ inputs.version || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          chart_file="charts/tero-edge/Chart.yaml"
+          version="${RAW_VERSION#v}"
+
+          if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unsupported app version format: ${version}" >&2
+            exit 1
+          fi
+
+          current="$(awk '/^appVersion:[[:space:]]*/ {print $2; exit}' "${chart_file}")"
+          if [ "${current}" = "${version}" ]; then
+            echo "Chart appVersion is already ${version}; nothing to sync."
+            exit 0
+          fi
+
+          awk -v v="${version}" '
+            /^appVersion:[[:space:]]*/ && !done { print "appVersion: " v; done=1; next }
+            { print }
+          ' "${chart_file}" > "${chart_file}.tmp"
+          mv "${chart_file}.tmp" "${chart_file}"
+
+          if git diff --quiet -- "${chart_file}"; then
+            echo "No change to ${chart_file}; nothing to sync." >&2
+            exit 1
+          fi
+
+          branch="chore/sync-chart-appversion-${version}"
+          title="fix(charts): sync appVersion to ${version}"
+
+          open_prs="$(gh pr list --head "${branch}" --state open --json number --jq 'length')"
+          if [ "${open_prs}" != "0" ]; then
+            echo "PR for ${branch} is already open; nothing to do."
+            exit 0
+          fi
+
+          git config user.name "tero-bot[bot]"
+          git config user.email "tero-bot[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git add "${chart_file}"
+          git commit -m "${title}"
+          git push --force-with-lease origin "${branch}"
+
+          body="$(cat <<EOF
+          Syncs the chart appVersion to the app release \`v${version}\`.
+
+          Merging this gives release-please a \`fix\` touching \`charts/tero-edge\`, so
+          the chart is versioned, tagged, released and published through its normal
+          path.
+
+          Opened automatically by \`.github/workflows/sync-chart-appversion.yaml\`.
+          EOF
+          )"
+
+          gh pr create \
+            --base master \
+            --head "${branch}" \
+            --title "${title}" \
+            --body "${body}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,14 +3,7 @@
   "include-v-in-tag": true,
   "packages": {
     ".": {
-      "release-type": "simple",
-      "extra-files": [
-        {
-          "type": "yaml",
-          "path": "charts/tero-edge/Chart.yaml",
-          "jsonpath": "$.appVersion"
-        }
-      ]
+      "release-type": "simple"
     },
     "charts/tero-edge": {
       "release-type": "helm",


### PR DESCRIPTION
The custom chart-bump step wrote the chart version into Chart.yaml and .release-please-manifest.json on the release PR branch. release-please only
tags packages it lists in the release PR body it generates, so a version injected out-of-band was never tagged, never released and never got a changelog entry -- while publish-helm-chart.yaml still shipped the .tgz off
the app tag. That left 17 published chart versions with no git tag and duplicated sections in the chart changelog.

Instead, after an app release a workflow opens an ordinary "fix(charts): sync appVersion to X" PR. Merging it gives release-please a
releasable commit touching charts/tero-edge, so the chart is versioned, tagged, released and published through its normal path.

appVersion is deliberately no longer a release-please extra-file: if it were
written during the app release PR the sync commit would be an empty diff and
the chart would never be released.

publish-helm-chart.yaml no longer triggers on v* app tags, which would otherwise repackage the unchanged chart version with a new appVersion and
overwrite an already-published .tgz.