### PR TITLE
fix: update to policy-zig 0.7.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -49,8 +49,8 @@
             .hash = "zbench-0.13.0-YTdc7xVBAQCCMC-IdLLuotBeiNNNm8k9Pi2V4VYqrwfI",
         },
         .policy_zig = .{
-            .url = "https://github.com/usetero/policy-zig/archive/refs/tags/v0.7.0.tar.gz",
-            .hash = "policy_zig-0.7.0-5_dp3qqnFQBMOLHViVc_0XhuiMadfzsdee3oGpASi1T5",
+            .url = "https://github.com/usetero/policy-zig/archive/refs/tags/v0.7.1.tar.gz",
+            .hash = "policy_zig-0.7.1-5_dp3p2xFQBbmLeyvcX53ti9iBJhzcn-e1EccJeb0UKF",
         },
     },
     .paths = .{


### PR DESCRIPTION
Fixes #258

Bumps `policy_zig` from v0.7.0 to v0.7.1. That is the whole diff.

## Why

0.7.0 compiled literal matchers into Hyperscan patterns without escaping regex metacharacters, so `exact`, `starts_with`, `ends_with` and `contains` were interpreted as regex. That failed two ways.

**Loud.** An unbalanced metacharacter fails to compile, so the policy goes inert and the edge logs an error per evaluated record:

```json
{ "log_field": "body", "starts_with": "Batch complete [count=" }
```
```
log: match[0]: invalid pattern "Batch complete [count="
```

**Quiet.** A literal whose metacharacters balance compiles and over-matches, with no error:

| matcher | also matched |
| --- | --- |
| `exact: "com.example.Service"` | `comXexampleXService` |
| `contains: "a*b"` | `aaab` |
| `contains: "1+1"` | `11` |

## The upstream fix

usetero/policy-zig#94 escapes every non-regex match type inside `formatPattern`, the one place both the validation path and the build path already share. `regex` still passes through untouched. This matches `policy-rs` `src/engine/compiled.rs:828-871`, which already escapes all four kinds.

## Verification

- The 0.7.1 tarball carries the fix: `formattedPatternLen` is present and the old `escapeRegexLiteral` helper is gone.
- `zig build` exits 0.
- `zig build test`: 514 pass, 1 skip, 7 of 7 steps succeed — the same as the 0.7.0 baseline.
- Upstream: 447 tests pass, including an end-to-end case that asserts `Batch complete [count=` compiles and matches, and that `com.example.Service` rejects `comXexampleXService`.
